### PR TITLE
Workaround failing library import

### DIFF
--- a/assets/init.scm
+++ b/assets/init.scm
@@ -37,7 +37,6 @@
 (import (editor types primitive))
 (import (editor input evaluation))
 (import (editor types extensions visual-stepper))
-(import (editor types extensions testing))
 (import (editor document history-tracking))
 (import (editor types spaces))
 (import (editor document copy-paste))


### PR DESCRIPTION
When running grasp-desktop, I have the following exception:

```
<eval>: unknown library (editor types extensions testing)

	at kawa.lang.Eval.evalBody(Eval.java:103)

```

And nothing appears in the editor.

Removing the import for `(editor types extensions testing)` addressed the problem, I can use the editor.